### PR TITLE
alias check updates

### DIFF
--- a/src/DependencyInjector.php
+++ b/src/DependencyInjector.php
@@ -192,11 +192,21 @@ class DependencyInjector
   public function hasShared($abstract, ?string $checkMode = null): bool
   {
     $exists = isset($this->_instances[$abstract]);
+
+    if(!$exists && isset($this->_aliases[$abstract]))
+    {
+      return $this->hasShared(...$this->_aliases[$abstract]);
+    }
+
     return !$exists || $checkMode === null ? $exists : $this->_instances[$abstract]['mode'] === $checkMode;
   }
 
   public function isAvailable($abstract, $shared = null): bool
   {
+    if(isset($this->_aliases[$abstract]))
+    {
+      return $this->isAvailable($this->_aliases[$abstract][0]);
+    }
     if($shared === false)
     {
       return isset($this->_factories[$abstract]);

--- a/src/DependencyInjector.php
+++ b/src/DependencyInjector.php
@@ -195,7 +195,7 @@ class DependencyInjector
 
     if(!$exists && isset($this->_aliases[$abstract]))
     {
-      return $this->hasShared(...$this->_aliases[$abstract]);
+      return $this->hasShared($this->_aliases[$abstract][0], $checkMode);
     }
 
     return !$exists || $checkMode === null ? $exists : $this->_instances[$abstract]['mode'] === $checkMode;
@@ -205,7 +205,7 @@ class DependencyInjector
   {
     if(isset($this->_aliases[$abstract]))
     {
-      return $this->isAvailable($this->_aliases[$abstract][0]);
+      return $this->isAvailable($this->_aliases[$abstract][0], $shared);
     }
     if($shared === false)
     {

--- a/tests/DependencyInjectorTest.php
+++ b/tests/DependencyInjectorTest.php
@@ -254,6 +254,44 @@ class DependencyInjectorTest extends TestCase
     static::assertEquals('dark apple', $result);
   }
 
+  public function testAliasIsAvailable()
+  {
+    $di = new DependencyInjector();
+
+    $this->assertFalse($di->isAvailable(CacheInterface::class));
+    $di->aliasAbstract(CacheInterface::class, Cache::class);
+    $this->assertFalse($di->isAvailable(CacheInterface::class));
+
+    $di->share(Cache::class, new Cache());
+    $this->assertTrue($di->isAvailable(CacheInterface::class));
+    $this->assertTrue($di->isAvailable(CacheInterface::class, true));
+
+    $di2 = new DependencyInjector();
+    $di2->aliasAbstract(CacheInterface::class, Cache::class);
+    $di2->factory(Cache::class, fn() => new Cache());
+    $this->assertTrue($di2->isAvailable(CacheInterface::class, false));
+  }
+
+  public function testAliasHasShared()
+  {
+    $di = new DependencyInjector();
+    $di->aliasAbstract(CacheInterface::class, Cache::class);
+    $this->assertFalse($di->hasShared(CacheInterface::class));
+
+    $di->share(Cache::class, new Cache());
+    $this->assertTrue($di->hasShared(CacheInterface::class));
+  }
+
+  public function testAliasHasSharedWithCheckMode()
+  {
+    $di = new DependencyInjector();
+    $di->aliasAbstract(CacheInterface::class, Cache::class);
+    $di->share(Cache::class, new Cache(), DependencyInjector::MODE_IMMUTABLE);
+
+    $this->assertTrue($di->hasShared(CacheInterface::class, DependencyInjector::MODE_IMMUTABLE));
+    $this->assertFalse($di->hasShared(CacheInterface::class, DependencyInjector::MODE_MUTABLE));
+  }
+
   public function testAliasAbstract()
   {
     $di = new DependencyInjector();

--- a/tests/DependencyInjectorTest.php
+++ b/tests/DependencyInjectorTest.php
@@ -265,6 +265,7 @@ class DependencyInjectorTest extends TestCase
     $di->share(Cache::class, new Cache());
     $this->assertTrue($di->isAvailable(CacheInterface::class));
     $this->assertTrue($di->isAvailable(CacheInterface::class, true));
+    $this->assertFalse($di->isAvailable(CacheInterface::class, false));
 
     $di2 = new DependencyInjector();
     $di2->aliasAbstract(CacheInterface::class, Cache::class);


### PR DESCRIPTION
I think this may be a bug whereby we are not checking if anything has been aliased in either the `hasShared` or `isAvailable` methods in the DI.

This means for our use case when we do something like:

```php 
$cubex->aliasAbstract(Flags::class, CustomFlags::class);
$cubex->share(new CustomFlags());

// ... Some other part of the application 
$cubex->isAvailable(Flags::class); // returns false
$cubex->hasShared(Flags::class); // returns false
```

My interpretation of this would be the above example should return `true` as it has been shared but via it's alias rather than the direct class.